### PR TITLE
ログイン Remember me 機能追加

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,6 +6,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
       log_in user
+      remember user
       flash.now[:success] = "ログインしました"
       redirect_to user # user_url(user)
     else

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:session][:email].downcase)
     if user && user.authenticate(params[:session][:password])
       log_in user
-      remember user
+      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
       flash.now[:success] = "ログインしました"
       redirect_to user # user_url(user)
     else
@@ -16,7 +16,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out
+    log_out if logged_in?
     render 'new'
   end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -5,9 +5,25 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
+  # ユーザーのセッションを永続的にする
+  def rember(user)
+    user.remember
+    cookies.permanent.sigend[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end
+
   # 現在ログイン中のユーザーがいる場合に、そのユーザーを返す
+  # 記憶トークンcookieに対応するユーザーを返す
   def current_user
-    @current_user ||= User.find_by(id: session[:user_id])
+    if(user_id = session[:user_id])
+      @current_user ||= User.find_by(id: session[:user_id])
+    elsif (user_id = cookies.signed[:user_id])
+      user = User.find_by(id: user_id)
+      if user && user.authenticated?(cookies[:remember_token])
+        log_in user
+        @current_user = user
+      end
+    end
   end
 
   # ユーザーがログインしていればtrue、その他ならfalseを返す

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -6,9 +6,9 @@ module SessionsHelper
   end
 
   # ユーザーのセッションを永続的にする
-  def rember(user)
+  def remember(user)
     user.remember
-    cookies.permanent.sigend[:user_id] = user.id
+    cookies.permanent.signed[:user_id] = user.id
     cookies.permanent[:remember_token] = user.remember_token
   end
 
@@ -31,8 +31,16 @@ module SessionsHelper
     !current_user.nil?
   end
 
+  # 永続的セッションを破棄する
+  def forget(user)
+    user.forget
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
+  end
+
   # 現在のユーザーをログアウトする
   def log_out
+    forget(current_user)
     session.delete(:user_id)
     @current_user = nil
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,4 +20,9 @@ class User < ApplicationRecord
                                                    BCrypt::Engine.cost
    BCrypt::Password.create(string, cost: cost)
   end
+
+  # ランダムなトークンを返す
+  def User.new_token
+    SecureRandom.urlsafe_base64
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ApplicationRecord
 
   # 渡されたトークンがダイジェストと一致したらtrueを返す
   def authenticated?(remember_token)
+    return false if remember_digest.nil?
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,14 +16,14 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum: 6 }
 
   # 渡された文字列のハッシュ値を返す
-  def User.digest(string)
+  def self.digest(string)
    cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                    BCrypt::Engine.cost
    BCrypt::Password.create(string, cost: cost)
   end
 
   # ランダムなトークンを返す
-  def User.new_token
+  def self.new_token
     SecureRandom.urlsafe_base64
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,11 @@ class User < ApplicationRecord
   # authenticateメソッドの定義
 
   validates :password, presence: true, length: { minimum: 6 }
+
+  # 渡された文字列のハッシュ値を返す
+  def User.digest(string)
+   cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
+                                                   BCrypt::Engine.cost
+   BCrypt::Password.create(string, cost: cost)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,4 +32,9 @@ class User < ApplicationRecord
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))
   end
+
+  # 渡されたトークンがダイジェストと一致したらtrueを返す
+  def authenticated?(remember_token)
+    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,4 +37,9 @@ class User < ApplicationRecord
   def authenticated?(remember_token)
     BCrypt::Password.new(remember_digest).is_password?(remember_token)
   end
+
+  # ユーザーのログイン情報を破棄する
+  def forget
+    update_attribute(:remember_digest, nil)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  attr_accessor :remember_token
   before_save { self.email = email.downcase } # データベースに保存するために全ての文字列を小文字に変換を行う
   # self.email.downcaseでも良かったが、右辺は省略可能
 
@@ -24,5 +25,11 @@ class User < ApplicationRecord
   # ランダムなトークンを返す
   def User.new_token
     SecureRandom.urlsafe_base64
+  end
+
+  # 永続化セッションのためにユーザーをデータベースに記憶する
+  def remember
+    self.remember_token = User.new_token
+    update_attribute(:remember_digest, User.digest(remember_token))
   end
 end

--- a/app/views/sessions/new.slim
+++ b/app/views/sessions/new.slim
@@ -8,6 +8,11 @@ h2 Log in
   = f.label :password
   = f.password_field :password
 
+  = f.label :remember_me do
+    = f.check_box :remember_me
+    span Remember me on this computer
+
+
   = f.submit "Log in"
 
   = link_to "Sign up now!", signup_path

--- a/db/migrate/20171109134441_add_remember_digest_to_users.rb
+++ b/db/migrate/20171109134441_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171023113739) do
+ActiveRecord::Schema.define(version: 20171109134441) do
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20171023113739) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.string "remember_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,4 @@
+michael:
+  name: Michael Example
+  email: michael@example.com
+  password_digest: <%= User.digest('password') %>

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class SessionsHelperTest < ActionView::TestCase
+
+  def setup
+    @user = users(:michael)
+    remember(@user)
+  end
+
+  test "current_user returns right user when session is nil" do
+    assert_equal @user, current_user
+    assert is_logged_in?
+  end
+
+  test "current_user returns nil when remember digest is wrong" do
+    @user.update_attribute(:remember_digest, User.digest(User.new_token))
+    assert_nil current_user
+  end
+end

--- a/test/integration/users_login_test.rb
+++ b/test/integration/users_login_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class UsersLoginTest < ActionDispatch::IntegrationTest
 
+  def setup
+    @user = users(:michael)
+  end
+
   test "login with invalid information" do
     get login_path
     assert_template 'sessions/new'
@@ -12,4 +16,17 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     # assert flash.empty?
   end
 
+  test "login with remembering" do
+    log_in_as(@user, remember_me: '1')
+    assert_not_empty cookies['remember_token']
+  end
+
+  test "login without remembering" do
+    # クッキーを保存してログイン
+    log_in_as(@user, remember_me: '1')
+    delete logout_path
+    # クッキーを削除してログイン
+    log_in_as(@user, remember_me: '0')
+    assert_empty cookies['remember_token']
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,5 +9,23 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
-  # Add more helper methods to be used by all tests here...
+  # テストユーザーがログイン中の場合にtrueを返す
+  def is_logged_in?
+    !session[:user_id].nil?
+  end
+
+  # テストユーザーとしてログインする
+  def log_in_as(user)
+    session[:user_id] = user.id
+  end
+end
+
+class ActionDispatch::IntegrationTest
+
+  # テストユーザーとしてログインする
+  def log_in_as(user, password: 'password', remember_me: '1')
+    post login_path, params: { session: { email: user.email,
+                                          password: password,
+                                          remember_me: remember_me } }
+  end
 end


### PR DESCRIPTION
# what
- [ ] Remember me機能

ブラウザを再起動した後でもすぐにログインできる機能
ユーザーが明示的にログアウトを実行しない限り、ログイン状態を維持することができる

1.記憶トークンにはランダムな文字列を生成して用いる。
2.ブラウザのcookiesにトークンを保存するときには、有効期限を設定する。
3.トークンはハッシュ値に変換してからデータベースに保存する。
4.ブラウザのcookiesに保存するユーザーIDは暗号化しておく。
5.永続ユーザーIDを含むcookiesを受け取ったら、そのIDでデータベースを検索し、記憶トークンのcookiesがデータベース内のハッシュ値と一致することを確認する。